### PR TITLE
missed commiting null return value

### DIFF
--- a/ext/dep_gecode/dep_selector_to_gecode.cpp
+++ b/ext/dep_gecode/dep_selector_to_gecode.cpp
@@ -513,7 +513,7 @@ IntVar * VersionProblem::GetPackageVersionVar(int packageId)
             DEBUG_STREAM << debugPrefix << "Bad package Id " << packageId << " >= " << cur_package << std::endl;
             DEBUG_STREAM.flush();
         }
-        //     return 0;
+        return NULL;
     }
 }
 


### PR DESCRIPTION
Add a missed NULL return value that slipped through the last bit of work to fix LLVM warnings. 

@danielsdeleo @sersut @sethvargo 
