### PR TITLE
Define a dummy init function for ruby's build to export

### DIFF
--- a/ext/dep_gecode/define_dummy_init.cxx
+++ b/ext/dep_gecode/define_dummy_init.cxx
@@ -1,0 +1,7 @@
+// On some platforms, the ruby compile process really wants to export an
+// Init_dep_gecode function.
+
+extern "C"
+
+void Init_dep_gecode(void) {
+}


### PR DESCRIPTION
Compiling on windows requires us to have a function named `Init_dep_gecode` even though we'll never call it. Without this function, installing the latest dep_selector fails on windows with:

```
Cannot export Init_dep_gecode: symbol not defined
```

The Makefile generated on windows contains:

```
$(DEFFILE):
        $(ECHO) generating $(@)
        $(Q) $(RUBY) -e "puts 'EXPORTS', '$(TARGET_ENTRY)'"  > $@
```

Where:

```
# snip
dldflags =  -Wl,--enable-auto-image-base,--enable-auto-import $(DEFFILE)
# snip
TARGET_NAME = dep_gecode
TARGET_ENTRY = Init_$(TARGET_NAME)
# snip
$(DLLIB): $(DEFFILE) $(OBJS) Makefile                                                 
        $(ECHO) linking shared-object $(DLLIB)                                        
        -$(Q)$(RM) $(@)                                                               
        $(Q) $(LDSHAREDXX) -o $@ $(OBJS) $(LIBPATH) $(DLDFLAGS) $(LOCAL_LIBS) $(LIBS)
```

This isn't really fixable in `mkmf`, it's easier if we just export this function, even though it's an ugly solution.
