### PR TITLE
Add .def file to export required symbols on windows

### DIFF
--- a/dep_selector.gemspec
+++ b/dep_selector.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'gecode, version 3.5 or greater'
   s.requirements << 'g++'
-  s.files = Dir.glob("lib/**/*.{rb}") + Dir.glob("ext/**/*.{i,c,cxx,h,cpp,rb}")
+  s.files = Dir.glob("lib/**/*.{rb}") + Dir.glob("ext/**/*.{i,c,cxx,h,cpp,rb,def}")
   s.extensions = Dir["ext/**/extconf.rb"]
 
   s.required_ruby_version = ">= 1.9.2"

--- a/ext/dep_gecode/dep_gecode-all.def
+++ b/ext/dep_gecode/dep_gecode-all.def
@@ -1,0 +1,16 @@
+EXPORTS
+VersionProblemCreate
+VersionProblemDestroy
+AddPackage
+VersionProblemSize
+MarkPackagePreferredToBeAtLatest
+MarkPackageRequired
+AddVersionConstraint
+Solve
+GetDisabledVariableCount
+GetPackageVersion
+MarkPackageSuspicious
+GetPackageDisabledState
+VersionProblemPackageCount
+GetPackageMax
+GetPackageMin

--- a/ext/dep_gecode/extconf.rb
+++ b/ext/dep_gecode/extconf.rb
@@ -93,6 +93,13 @@ EOS
     raise "Gecode not installed"
   end
 
+  if RUBY_PLATFORM =~ /mswin|mingw|windows/
+    # By default, ruby will generate linker options that will not export the
+    # symbols we need to export. We pass an extra def file to the linker to
+    # make it export the symbols we need.
+    $DLDFLAGS << " -Wl,--enable-auto-image-base,--enable-auto-import dep_gecode-all.def"
+  end
+
   create_makefile('dep_gecode')
 else # JRUBY
 


### PR DESCRIPTION
Ruby is passing linker options that result in not exporting the actual symbols we need (these are the functions we attach via ffi).
