### PR TITLE
fixes berkshelf trivial solve failure bug

### DIFF
--- a/lib/dep_selector/error_reporter/simple_tree_traverser.rb
+++ b/lib/dep_selector/error_reporter/simple_tree_traverser.rb
@@ -80,13 +80,14 @@ module DepSelector
         # version_constraint and recurse into them
         seen_dep_trees = {}
         curr_pkg[version_constraint].each do |curr_pkg_ver|
-          next if seen_dep_trees.has_key?(curr_pkg_ver.dependencies.to_s)
+          key = curr_pkg_ver.dependencies.map{|d| d.to_s}.join(', ')
+          next if seen_dep_trees.has_key?(key)
           curr_path.push(curr_pkg_ver)
           curr_pkg_ver.dependencies.each do |dep|
             next if curr_pkg.name == dep.package.name
             paths_to_pkg(dep_graph, dep.package, dep.constraint, target_pkg, curr_path, all_paths)
           end
-          seen_dep_trees[curr_pkg_ver.dependencies.to_s] = true
+          seen_dep_trees[key] = true
           curr_path.pop
         end
       end


### PR DESCRIPTION
the probelm here is that calling Array#to_s winds up calling
the #inspect method on all the contents, not the #to_s method.

turns out that with berkshelf calling #inspect winds up walking
some instance variables that have the whole 'universe' of cookbooks
and the first line this patches takes a very long time to even
set the first key value.

by rolling out our own iterator over the array and calling to_s
we avoid descending into instance variables that include the
universe and this completes.

should also improve the cpu processing of exceptions on orgs with
large cookbook collections on EC as well.
