### PR TITLE
extconf.rb: load rubygems

### DIFF
--- a/ext/dep_gecode/extconf.rb
+++ b/ext/dep_gecode/extconf.rb
@@ -24,6 +24,7 @@ if !defined?(RUBY_ENGINE) || RUBY_ENGINE == 'ruby' || RUBY_ENGINE == 'rbx'
   # ./configure --with-architectures=i386,x86_64
   # to work properly here.
   require 'mkmf'
+  require 'rubygems'
   require 'dep-selector-libgecode'
 
   opt_path = DepSelectorLibgecode.opt_path


### PR DESCRIPTION
load rubygems, so `gem install dep_selector -v '1.0.3'` would able to find `dep-selector-libgecode` gem

this is for ruby builds where `rubygems.rb` load is not compiled in
