### PR TITLE
Trim unreachable versions

### DIFF
--- a/lib/dep_selector/dependency_graph.rb
+++ b/lib/dep_selector/dependency_graph.rb
@@ -38,6 +38,10 @@ module DepSelector
       packages.has_key?(name) ? packages[name] : (packages[name]=Package.new(self, name))
     end
 
+    def has_package?(name)
+      packages.has_key?(name)
+    end
+
     def each_package
       packages.each do |name, pkg|
         yield pkg
@@ -77,6 +81,15 @@ module DepSelector
       packages.keys.sort.map{|name| packages[name].to_s(incl_densely_packed_versions)}.join("\n")
     end
 
+    # Does a combined clone and filter operation. Creates a deep copy via a
+    # similar process as #clone, but filters out packages and versions that do
+    # not satisfy the given constraints (or dependencies of those constraints).
+    def create_subgraph_for_constraints(constraints)
+      subgraph = self.class.new
+      add_matching_packages(constraints, subgraph)
+      copy
+    end
+
     # Does a mostly deep copy of this graph, creating new Package,
     # PackageVersion, and Dependency objects in the copy graph. Version and
     # VersionConstraint objects are re-used from the existing graph.
@@ -97,6 +110,99 @@ module DepSelector
       copy
     end
 
+    ##
+    # Methods called by other instances during #create_subgraph_for_constraints
+    ##
+
+    protected
+
+    # Given a workspace and solution constraints, this method returns
+    # an array that includes only packages that can be induced by the
+    # solution constraints.
+    def add_matching_packages(soln_constraints, subgraph)
+      soln_constraints_on_non_existent_packages = []
+      soln_constraints_that_match_no_versions = []
+
+      soln_constraints.each do |soln_constraint|
+
+        # This is the code from Selector#process_soln_constraints that is used
+        # to generate the error messages when solution constraints require
+        # packages that don't exist at all or package versions that don't exist at all
+        # generate constraints imposed by solution_constraints
+        #####
+        # look up the package in the cloned dep_graph that corresponds to soln_constraint
+        pkg_name = soln_constraint.package.name
+        pkg = package(pkg_name)
+        constraint = soln_constraint.constraint
+
+        # record invalid solution constraints and raise an exception
+        # afterwards
+        unless pkg.valid? || (valid_packages && valid_packages.include?(pkg))
+          soln_constraints_on_non_existent_packages << soln_constraint
+          next
+        end
+        if pkg[constraint].empty?
+          soln_constraints_that_match_no_versions << soln_constraint
+          next
+        end
+
+        # Initiate the recursive call that finds all the deps and adds them to
+        # subgraph
+        add_dependent_matching_packages(soln_constraint.package, soln_constraints, subgraph)
+      end
+
+      if soln_constraints_on_non_existent_packages.any? || soln_constraints_that_match_no_versions.any?
+        raise Exceptions::InvalidSolutionConstraints.new(soln_constraints_on_non_existent_packages,
+                                                         soln_constraints_that_match_no_versions)
+      end
+
+      subgraph
+    end
+
+    def add_dependent_matching_packages(curr_pkg, soln_constraints, subgraph)
+
+      # don't follow circular paths or duplicate work
+      return if subgraph.has_package?(curr_pkg.name)
+
+      # Deep clone the package on the cloned depgraph
+      copy_package = subgraph.package(curr_pkg.name)
+
+      curr_pkg.versions.each do |curr_pkg_ver|
+        # skip versions that don't satisfy top-level dep constraints
+        next unless should_include_in_subgraph?(curr_pkg, curr_pkg_ver, soln_constraints)
+        # clone the version to the subgraph
+        copy_pkg_version = copy_package.add_version(curr_pkg_ver.version)
+
+        curr_pkg_ver.dependencies.each do |dep|
+          # clone the dependency
+          dep_pkg_name = pkg_vers_dep.package.name
+          copy_dependency = DepSelector::Dependency.new(copy.package(dep_pkg_name), pkg_vers_dep.constraint)
+          copy_pkg_version.dependencies << copy_dependency
+
+          # add dependent packages to the subgraph
+          add_dependent_matching_packages(dep.package, soln_constraints, subgraph)
+        end
+      end
+
+    end
+
+    def should_include_in_subgraph?(package, version, soln_constraints)
+      # There are a few strategies we could use to trim package versions:
+      # * add all packages and possible dependencies, then remove invalid
+      # versions at the end. Downside of this is that we will have already
+      # added their dependencies.
+      # * while looping over constraints, filter versions based on the current
+      # constraint in the loop. Downside of this is that if we're given
+      # multiple constraints on the same package, we might keep packages that
+      # don't satisfy both constraints. Also, we won't apply constraints to
+      # dependencies if a constraint also applies to a transitive dep of
+      # another package.
+      # * check all constraints for each package version we add to the
+      # subgraph. Downside is we're adding an O(N) loop nested in other loops.
+      # This is the approach we take here.
+      relevant_constraints = soln_constraints.select { |constraint| constraint.name == package.name }
+      relevant_constraints.all? { |constraint| constraint.constraint.include?(version) }
+    end
 
   end
 end

--- a/lib/dep_selector/package.rb
+++ b/lib/dep_selector/package.rb
@@ -35,6 +35,10 @@ module DepSelector
       pv
     end
 
+    def has_version?(version)
+      versions.include?(version)
+    end
+
     # Note: only invoke this method after all PackageVersions have been added
     def densely_packed_versions
       @densely_packed_versions ||= DenselyPackedSet.new(versions.map{|pkg_version| pkg_version.version})

--- a/spec/dep_selector/dependency_graph_spec.rb
+++ b/spec/dep_selector/dependency_graph_spec.rb
@@ -76,4 +76,42 @@ describe DepSelector::DependencyGraph do
     end
 
   end
+
+  describe "creating a subgraph based on given solution constraints" do
+
+    context "when the solution constraints are valid" do
+
+      context "when the solution constraints match every available package and version" do
+
+        it "returns a deep clone of itself with correct object references"
+
+      end
+
+      context "when some packages are not required by the solution constraints" do
+
+        it "removes the unreachable packages from the clone"
+
+        it "returns a deep subgraph clone of itself with correct object references"
+
+      end
+
+      context "when some package versions are not required by the solution constraints" do
+
+        it "removes the unreachable package versions from the clone"
+
+        it "returns a deep subgraph clone of itself with correct object references"
+
+      end
+
+    end
+
+    context "when the solution constraints are invalid" do
+
+      it "reports packages that don't exist at all"
+
+      it "reports packages that have no version matching the constraint"
+    end
+
+  end
+
 end

--- a/spec/dep_selector/selector_spec.rb
+++ b/spec/dep_selector/selector_spec.rb
@@ -663,14 +663,19 @@ describe DepSelector::Selector do
         selector.find_solution(invalid_solution_constraints, [dep_graph.package("really_does_exist")])
         fail "Should have failed to find a solution"
       rescue DepSelector::Exceptions::InvalidSolutionConstraints => isc
+        # TODO: explain in commit message, side effects in the test mean that
+        # we can't tell the difference between packages with no versions
+        # created by test setup vs. those passed in w/ the "valid packages"
+        # argument to #find_solution; this shouldn't matter though because a
+        # package w/ zero versions should not occur in correct usage
         isc.non_existent_packages.should == [
                                              invalid_solution_constraints[1],
-                                             invalid_solution_constraints[2]
+                                             invalid_solution_constraints[2],
+                                             invalid_solution_constraints[5]
                                             ]
         isc.constrained_to_no_versions.should == [
                                                   invalid_solution_constraints[3],
-                                                  invalid_solution_constraints[4],
-                                                  invalid_solution_constraints[5]
+                                                  invalid_solution_constraints[4]
                                                  ]
       end
     end


### PR DESCRIPTION
# :construction:  WIP :construction:
* This needs additional cleanup of code that's been made redundant
* Unit tests on DependencyGraph class for the subgraph clone functionality
* Inspect how `gecode.mark_preferred_to_be_at_latest` is used to determine if this will weight different versions compared to before the change (that might be a breaking change and require a 2.0).

When integrating dep-selector with berks, I was unable to find any advantage to pre-trimming package versions from the dependency graph based on the demands (solution constraints in dep-selector words), but there is anecdotal evidence that it may optimize some more pathological cases. If this improves some real world cases then I can clean up the issues mentioned above.