### PR TITLE
Ma/c timeout

### DIFF
--- a/ext/dep_gecode/dep_selector_to_gecode.cpp
+++ b/ext/dep_gecode/dep_selector_to_gecode.cpp
@@ -617,7 +617,11 @@ VersionProblem * VersionProblem::InnerSolve(VersionProblem * problem, int &iterc
     DEBUG_STREAM << "Creating solver" << std::endl << std::flush;
 #endif
     VersionProblem *best_solution = NULL;
-    Restart<VersionProblem> solver(problem);
+    int ms_remaining = 10000; // make sure this accumulates over multiple steps.
+    Search::TimeStop timeStop(ms_remaining);
+    Search::Options options;
+    options.stop = &timeStop;
+    Restart<VersionProblem> solver(problem, options);
 
 #ifdef MEMORY_DEBUG
     DEBUG_STREAM << "Starting Solve" << std::endl << std::flush;

--- a/ext/dep_gecode/dep_selector_to_gecode.cpp
+++ b/ext/dep_gecode/dep_selector_to_gecode.cpp
@@ -639,8 +639,7 @@ VersionProblem * VersionProblem::InnerSolve(VersionProblem * problem, int &iterc
     DEBUG_STREAM << "Starting Solve" << std::endl << std::flush;
 #endif
 
-    while (VersionProblem *solution = solver.next())
-        {
+    while (VersionProblem *solution = solver.next()) {
 #ifdef MEMORY_DEBUG
             DEBUG_STREAM << "Solver Next " << solution << std::endl << std::flush;
 #endif

--- a/ext/dep_gecode/dep_selector_to_gecode.cpp
+++ b/ext/dep_gecode/dep_selector_to_gecode.cpp
@@ -100,9 +100,10 @@ void VersionProblemPool::DeleteAll()
 
 int VersionProblem::instance_counter = 0;
 
-VersionProblem::VersionProblem(int packageCount, bool dumpStats, bool debug, const char * logId)
+VersionProblem::VersionProblem(int packageCount, bool dumpStats, bool debug, const char * logId,
+    unsigned long int _timeout)
     : size(packageCount), version_constraint_count(0), dump_stats(dumpStats),
-      debugLogging(debug),
+      debugLogging(debug), timeout(_timeout), solutionState(SOLUTION_STATE_UNSTARTED),
       finalized(false), cur_package(0), package_versions(*this, packageCount),
       disabled_package_variables(*this, packageCount, 0, 1), total_disabled(*this, 0, packageCount*MAX_TRUST_LEVEL),
       total_required_disabled(*this, 0, packageCount), total_induced_disabled(*this, 0, packageCount),
@@ -128,7 +129,7 @@ VersionProblem::VersionProblem(int packageCount, bool dumpStats, bool debug, con
     if (debugLogging) {
         DEBUG_STREAM << std::endl;
         DEBUG_STREAM << debugPrefix << "Creating VersionProblem inst# " << instance_id << " with " << packageCount << " packages, "
-                     << dumpStats << " stats, " << debug << " debug" << std::endl;
+                     << dumpStats << " stats, " << debug << " debug " << timeout << " timeout" << std::endl;
         DEBUG_STREAM.flush();
     }
 }
@@ -137,7 +138,7 @@ VersionProblem::VersionProblem(bool share, VersionProblem & s)
     : Space(share, s),
       size(s.size), version_constraint_count(s.version_constraint_count),
       dump_stats(s.dump_stats),
-      debugLogging(s.debugLogging),
+      debugLogging(s.debugLogging), timeout(s.timeout), solutionState(s.solutionState),
       finalized(s.finalized), cur_package(s.cur_package),
       disabled_package_variables(s.disabled_package_variables), total_disabled(s.total_disabled),
       total_required_disabled(s.total_required_disabled), total_induced_disabled(s.total_induced_disabled),
@@ -310,6 +311,7 @@ void VersionProblem::Finalize()
         DEBUG_STREAM.flush();
     }
     finalized = true;
+    solutionState = SOLUTION_STATE_FINALIZED;
 
     // Setup constraint for cost
     // We wish to minimize the total number of disabled packages, by priority ranks
@@ -546,6 +548,16 @@ int VersionProblem::GetDisabledVariableCount()
     }
 }
 
+void VersionProblem::SetTimeout(unsigned long int _timeout)
+{
+    timeout = _timeout;
+}
+
+int VersionProblem::GetSolutionState()
+{
+    return solutionState;
+}
+
 
 // Utility
 void VersionProblem::Print(std::ostream & out)
@@ -617,8 +629,8 @@ VersionProblem * VersionProblem::InnerSolve(VersionProblem * problem, int &iterc
     DEBUG_STREAM << "Creating solver" << std::endl << std::flush;
 #endif
     VersionProblem *best_solution = NULL;
-    int ms_remaining = 10000; // make sure this accumulates over multiple steps.
-    Search::TimeStop timeStop(ms_remaining);
+    // This needs to accumulate over multiple steps.
+    Search::TimeStop timeStop(problem->timeout);
     Search::Options options;
     options.stop = &timeStop;
     Restart<VersionProblem> solver(problem, options);
@@ -637,6 +649,8 @@ VersionProblem * VersionProblem::InnerSolve(VersionProblem * problem, int &iterc
                     delete best_solution;
                 }
             best_solution = solution;
+            best_solution->solutionState = SOLUTION_STATE_SOLVED;
+
             ++itercount;
             if (problem->debugLogging) {
                 DEBUG_STREAM << problem->debugPrefix << "Trial Solution #" << itercount << "===============================" << std::endl;
@@ -647,12 +661,30 @@ VersionProblem * VersionProblem::InnerSolve(VersionProblem * problem, int &iterc
             }
         }
 
+    // If we fail to find a solution in time we treat it as no
+    // solution. We could return a special token to differentiate a
+    // timeout, but that could cause problems for the FFI interface.
+    if (solver.stopped()) {
+        best_solution->solutionState = SOLUTION_STATE_TIMED_OUT;
+        if (problem->debugLogging) {
+            DEBUG_STREAM << problem->debugPrefix << "Solver FAILED: timed out with timeout set to "
+                         << problem->timeout << " ms" << std::endl;
+            const Search::Statistics & stats = solver.statistics();
+            DEBUG_STREAM << problem->debugPrefix << "Solver stats: Prop:" << stats.propagate << " Fail:" << stats.fail << " Node:" << stats.node;
+            DEBUG_STREAM << " Depth:" << stats.depth << " memory:" << stats.memory << std::endl;
+        }
+
+    } else  {
+        best_solution->solutionState = SOLUTION_STATE_OPTIMAL;
+    }
+
     double elapsed_time = timer.stop();
 
     if (problem->dump_stats) {
         if (problem->debugLogging) std::cerr << problem->debugPrefix;
         std::cerr << "dep_selector solve: ";
-        std::cerr << (best_solution ? "SOLVED" : "FAILED") << " ";
+        std::cerr << ((best_solution &&  best_solution->solutionState == SOLUTION_STATE_OPTIMAL) ? "SOLVED" : "FAILED")
+                  << " ";
         std::cerr << problem->size << " packages, " << problem->version_constraint_count << " constraints, ";
         std::cerr << "Time: " << elapsed_time << "ms ";
         const Search::Statistics & final_stats = solver.statistics();
@@ -662,6 +694,7 @@ VersionProblem * VersionProblem::InnerSolve(VersionProblem * problem, int &iterc
         std::cerr << std::endl << std::flush;
     }
 
+    // We return null if there is no solution found. Timeout also returns null
     return best_solution;
 }
 

--- a/ext/dep_gecode/dep_selector_to_gecode.h
+++ b/ext/dep_gecode/dep_selector_to_gecode.h
@@ -21,7 +21,7 @@
 #define dep_selector_to_gecode_h
 
 #include "dep_selector_to_gecode_interface.h"
-#include <iostream>	       
+#include <iostream>
 #include <vector>
 #include <set>
 
@@ -39,10 +39,10 @@ using namespace Gecode;
 
 // Extend:
 // Add optimization functions
-// Allow non-contiguous ranges in package dependencies. 
+// Allow non-contiguous ranges in package dependencies.
 
-// TODO: Add locking 
-struct VersionProblemPool 
+// TODO: Add locking
+struct VersionProblemPool
 {
     std::set<VersionProblem *> elems;
     VersionProblemPool();
@@ -59,15 +59,16 @@ class VersionProblem : public Space
 {
 public:
   static const int UNRESOLVED_VARIABLE;
-  static const int MIN_TRUST_LEVEL;  
+  static const int MIN_TRUST_LEVEL;
   static const int MAX_TRUST_LEVEL;
   static const int MAX_PREFERRED_WEIGHT;
 
   static int instance_counter;
 
-    VersionProblem(int packageCount, bool dumpStats = true, 
-                   bool debug = false, 
-                   const char * logId = 0);
+  VersionProblem(int packageCount, bool dumpStats = true,
+                 bool debug = false,
+                 const char * logId = 0,
+                 unsigned long int _timeout = 10000);
   // Clone constructor; check gecode rules for this...
   VersionProblem(bool share, VersionProblem & s);
   virtual ~VersionProblem();
@@ -80,20 +81,20 @@ public:
   virtual int AddPackage(int minVersion, int maxVersion, int currentVersion);
 
   virtual void AddVersionConstraint(int packageId, int version,
-			    int dependentPackageId, int minDependentVersion, int maxDependentVersion);
+                            int dependentPackageId, int minDependentVersion, int maxDependentVersion);
 
-  // We may wish to indicate that some packages have suspicious constraints, and when chosing packages to disable we 
-  // would disable them first. 
+  // We may wish to indicate that some packages have suspicious constraints, and when chosing packages to disable we
+  // would disable them first.
   void MarkPackageSuspicious(int packageId);
 
-  void MarkPackageRequired(int packageId); 
+  void MarkPackageRequired(int packageId);
 
   // Packages marked by this method are preferentially chosen at
   // latest according to weights
   void MarkPackagePreferredToBeAtLatest(int packageId, int weight);
 
   void Finalize();
-  
+
   virtual void constrain(const Space & _best_known_solution);
 
   int GetPackageVersion(int packageId);
@@ -101,7 +102,10 @@ public:
   int GetMax(int packageId);
   int GetMin(int packageId);
   int GetDisabledVariableCount();
-  
+
+  void SetTimeout(unsigned long int _timeout);
+  int GetSolutionState();
+
   // Support for gecode
   virtual Space* copy(bool share);
 
@@ -122,6 +126,9 @@ public:
   bool debugLogging;
   char debugPrefix[DEBUG_PREFIX_LENGTH];
   char outputBuffer[1024];
+  unsigned long int timeout;
+  int solutionState;
+
   bool finalized;
 
   BoolVarArgs version_flags;
@@ -147,7 +154,7 @@ public:
   void AddPackagesPreferredToBeAtLatestObjectiveFunction(const VersionProblem & best_known_solution);
   void ConstrainVectorLessThanBest(IntVarArgs & current, IntVarArgs & best);
   void BuildCostVector(IntVarArgs & costVector) const;
- 
+
   friend class VersionProblemPool;
 };
 

--- a/ext/dep_gecode/dep_selector_to_gecode_interface.cpp
+++ b/ext/dep_gecode/dep_selector_to_gecode_interface.cpp
@@ -30,9 +30,10 @@
 
 // FFI friendly
 VersionProblem * VersionProblemCreate(int packageCount, bool dump_stats,
-                                      bool debug, const char * logId) 
+                                      bool debug, const char * logId,
+                                      unsigned long int _timeout)
 {
-  return new VersionProblem(packageCount, dump_stats, debug, logId);
+  return new VersionProblem(packageCount, dump_stats, debug, logId, _timeout);
 }
 
 void VersionProblemDestroy(VersionProblem * p)
@@ -40,12 +41,12 @@ void VersionProblemDestroy(VersionProblem * p)
   delete p;
 }
 
-int VersionProblemSize(VersionProblem *p) 
+int VersionProblemSize(VersionProblem *p)
 {
   return p->Size();
 }
 
-int VersionProblemPackageCount(VersionProblem *p) 
+int VersionProblemPackageCount(VersionProblem *p)
 {
   return p->PackageCount();
 }
@@ -58,7 +59,7 @@ void VersionProblemDump(VersionProblem *p)
   std::cout.flush();
 }
 
-void VersionProblemPrintPackageVar(VersionProblem *p, int packageId) 
+void VersionProblemPrintPackageVar(VersionProblem *p, int packageId)
 {
   p->PrintPackageVar(std::cout, packageId);
   std::cout.flush();
@@ -68,16 +69,16 @@ void VersionProblemPrintPackageVar(VersionProblem *p, int packageId)
 int AddPackage(VersionProblem *problem, int min, int max, int currentVersion) {
   return problem->AddPackage(min,max,currentVersion);
 }
-// Add constraint for package pkg @ version, 
+// Add constraint for package pkg @ version,
 // that dependentPackage is at version [minDependentVersion,maxDependentVersion]
 // Returns false if system becomes insoluble.
 void AddVersionConstraint(VersionProblem *problem, int packageId, int version,
-			  int dependentPackageId, int minDependentVersion, int maxDependentVersion) 
+                          int dependentPackageId, int minDependentVersion, int maxDependentVersion)
 {
   return problem->AddVersionConstraint(packageId, version, dependentPackageId, minDependentVersion, maxDependentVersion);
 }
 
-void MarkPackageSuspicious(VersionProblem *problem, int packageId) 
+void MarkPackageSuspicious(VersionProblem *problem, int packageId)
 {
   return problem->MarkPackageSuspicious(packageId);
 }
@@ -117,6 +118,15 @@ int GetDisabledVariableCount(VersionProblem *problem)
   return problem->GetDisabledVariableCount();
 }
 
+void SetTimeout(VersionProblem *problem, unsigned long int timeout)
+{
+    problem->SetTimeout(timeout);
+}
+
+int GetSolutionState(VersionProblem * problem)
+{
+    return problem->GetSolutionState();
+}
 
 VersionProblem * Solve(VersionProblem * problem)  {
   return VersionProblem::Solve(problem);

--- a/ext/dep_gecode/dep_selector_to_gecode_interface.h
+++ b/ext/dep_gecode/dep_selector_to_gecode_interface.h
@@ -25,6 +25,12 @@
 extern "C" {
 #endif // __cplusplus
 
+#define SOLUTION_STATE_UNSTARTED 1
+#define SOLUTION_STATE_FINALIZED 2
+#define SOLUTION_STATE_SOLVED    3
+#define SOLUTION_STATE_TIMED_OUT 4
+#define SOLUTION_STATE_OPTIMAL   5
+
 #ifdef __cplusplus
   class VersionProblem;
 #else
@@ -32,7 +38,8 @@ extern "C" {
 #endif // __cplusplus
 
   VersionProblem * VersionProblemCreate(int packageCount, bool dumpStats,
-                                        bool debug, const char * logId);
+                                        bool debug, const char * logId,
+                                        unsigned long int timeout);
   void VersionProblemDestroy(VersionProblem * vp);
 
 
@@ -41,11 +48,11 @@ extern "C" {
 
   // Return ID #
   int AddPackage(VersionProblem *problem, int min, int max, int currentVersion);
-  // Add constraint for package pkg @ version, 
+  // Add constraint for package pkg @ version,
   // that dependentPackage is at version [minDependentVersion,maxDependentVersion]
   // Returns false if system becomes insoluble.
   void AddVersionConstraint(VersionProblem *problem, int packageId, int version,
-			    int dependentPackageId, int minDependentVersion, int maxDependentVersion);
+                            int dependentPackageId, int minDependentVersion, int maxDependentVersion);
 
   void MarkPackageSuspicious(VersionProblem *problem, int packageId);
   void MarkPackageRequired(VersionProblem *problem, int packageId);
@@ -58,6 +65,9 @@ extern "C" {
   int GetPackageMin(VersionProblem *problem, int packageId);
 
   int GetDisabledVariableCount(VersionProblem *problem);
+
+  void SetTimeout(VersionProblem *problem, unsigned long int timeout);        
+  int GetSolutionState(VersionProblem *problem);
 
   void VersionProblemDump(VersionProblem * problem);
   void VersionProblemPrintPackageVar(VersionProblem * problem, int packageId);

--- a/lib/dep_selector/dep_gecode.rb
+++ b/lib/dep_selector/dep_gecode.rb
@@ -38,9 +38,9 @@ module Dep_gecode
 
   ffi_lib path
 
-  # VersionProblem * VersionProblemCreate(int packageCount, bool dumpStats, 
-  #                                       bool debug, const char * log_id);
-  attach_function :VersionProblemCreate, [:int, :bool, :bool, :string], :pointer
+  # VersionProblem * VersionProblemCreate(int packageCount, bool dumpStats,
+  #                                       bool debug, const char * log_id, unsigned long int _timeout);
+  attach_function :VersionProblemCreate, [:int, :bool, :bool, :string, :ulong], :pointer
 
   # void VersionProblemDestroy(VersionProblem * vp);
   attach_function :VersionProblemDestroy, [:pointer], :void
@@ -48,7 +48,7 @@ module Dep_gecode
   # int AddPackage(VersionProblem *problem, int min, int max, int currentVersion);
   attach_function :AddPackage, [:pointer, :int, :int, :int], :int
 
-  # int VersionProblemSize(VersionProblem *p); 
+  # int VersionProblemSize(VersionProblem *p);
   attach_function :VersionProblemSize, [:pointer], :int
 
   # void MarkPackagePreferredToBeAtLatest(VersionProblem *problem, int packageId, int weight);
@@ -84,6 +84,12 @@ module Dep_gecode
 
   # int GetPackageMin(VersionProblem *problem, int packageId);
   attach_function :GetPackageMin, [:pointer, :int], :int
+
+  # int GetSolutionState(VersionProblem * problem);
+  attach_function :GetSolutionState, [:pointer], :int
+
+  # void SetTimeout(VersionProblem * problem, unsigned long int);
+  attach_function :SetTimeout, [:pointer, :ulong], :void
+
+
 end
-
-

--- a/lib/dep_selector/gecode_wrapper.rb
+++ b/lib/dep_selector/gecode_wrapper.rb
@@ -42,14 +42,21 @@ module DepSelector
     DontCareConstraint = -1
     NoMatchConstraint = -2
 
+    # from dep_selector_to_gecode_interface.h
+    SolutionStateUnstarted = 1
+    SolutionStateFinalized =  2
+    SolutionStateSolved = 3
+    SolutionStateTimedOut = 4
+    SolutionStateOptimal = 5
+
     # This insures that we properly deallocate the c++ class at the heart of dep_gecode.
     # modeled after http://www.mikeperham.com/2010/02/24/the-trouble-with-ruby-finalizers/
-    def initialize(problem_or_package_count, logId, debug=false)
+    def initialize(problem_or_package_count, logId, debug=false, timeout = 10000)
       if (problem_or_package_count.is_a?(Numeric))
         dump_statistics = DepSelector.dump_statistics || debug
         @log_id = logId
         @debug_logs_on = debug
-        @gecode_problem = Dep_gecode.VersionProblemCreate(problem_or_package_count, dump_statistics, debug, logId)
+        @gecode_problem = Dep_gecode.VersionProblemCreate(problem_or_package_count, dump_statistics, debug, logId, 500)
       else
         @gecode_problem = problem_or_package_count
       end
@@ -157,11 +164,22 @@ module DepSelector
       Dep_gecode.MarkPackagePreferredToBeAtLatest(gecode_problem, package_id, weight);
     end
 
+    def set_timeout(timeout)
+      raise "Gecode internal failure (set_timeout)" if gecode_problem.nil?
+      Dep_gecode.SetTimeout(gecode_problem, timeout)
+    end
+    
+    def get_solution_state()
+      raise "Gecode internal failure (get_solution_state)" if gecode_problem.nil?
+      Dep_gecode.GetSolutionState(gecode_problem);
+    end
+   
     def solve()
       raise "Gecode internal failure (solve)" if gecode_problem.nil?
-      solution = GecodeWrapper.new(Dep_gecode.Solve(gecode_problem), log_id, debug_logs_on)
+      solution = GecodeWrapper.new(Dep_gecode.Solve(gecode_problem), log_id, debug_logs_on, @timeout)
       raise "Gecode internal failure (no solution found)" if (solution.nil?)
 
+      raise Exceptions::TimeBoundExceeded.new() if solution.get_solution_state == SolutionStateTimedOut
       raise Exceptions::NoSolutionFound.new(solution) if solution.package_disabled_count > 0
       solution
     end

--- a/lib/dep_selector/gecode_wrapper.rb
+++ b/lib/dep_selector/gecode_wrapper.rb
@@ -56,7 +56,8 @@ module DepSelector
         dump_statistics = DepSelector.dump_statistics || debug
         @log_id = logId
         @debug_logs_on = debug
-        @gecode_problem = Dep_gecode.VersionProblemCreate(problem_or_package_count, dump_statistics, debug, logId, 500)
+        @timeout = timeout
+        @gecode_problem = Dep_gecode.VersionProblemCreate(problem_or_package_count, dump_statistics, debug, logId, @timeout)
       else
         @gecode_problem = problem_or_package_count
       end
@@ -168,12 +169,12 @@ module DepSelector
       raise "Gecode internal failure (set_timeout)" if gecode_problem.nil?
       Dep_gecode.SetTimeout(gecode_problem, timeout)
     end
-    
+
     def get_solution_state()
       raise "Gecode internal failure (get_solution_state)" if gecode_problem.nil?
       Dep_gecode.GetSolutionState(gecode_problem);
     end
-   
+
     def solve()
       raise "Gecode internal failure (solve)" if gecode_problem.nil?
       solution = GecodeWrapper.new(Dep_gecode.Solve(gecode_problem), log_id, debug_logs_on, @timeout)

--- a/lib/dep_selector/selector.rb
+++ b/lib/dep_selector/selector.rb
@@ -67,11 +67,9 @@ module DepSelector
       packages_to_include_in_solve = trim_unreachable_packages(dep_graph, solution_constraints)
 
       begin
-        Timeout::timeout(@time_bound, Exceptions::TimeBoundExceeded) do
-          # first, try to solve the whole set of constraints
-          solve(dep_graph.clone, solution_constraints, valid_packages, packages_to_include_in_solve)
-        end
-      rescue Exceptions::NoSolutionFound
+        # first, try to solve the whole set of constraints
+        solve(dep_graph.clone, solution_constraints, valid_packages, packages_to_include_in_solve)
+      rescue Exceptions::NoSolutionFound, Exceptions::TimeBoundExceededNoSolution
         # since we're here, solving the whole system failed, so add
         # the solution_constraints one-by-one and try to solve in
         # order to find the constraint that breaks the system in order
@@ -148,6 +146,7 @@ module DepSelector
       process_soln_constraints(workspace, solution_constraints, valid_packages)
 
       # solve and trim the solution down to only the
+      workspace.gecode_wrapper.set_timeout(@time_bound * 1000)      
       soln = workspace.gecode_wrapper.solve
       trim_solution(solution_constraints, soln, workspace)
     end

--- a/spec/dep_gecode_spec.rb
+++ b/spec/dep_gecode_spec.rb
@@ -22,6 +22,7 @@ require File.expand_path(File.join(File.dirname(__FILE__), 'spec_helper'))
 require 'version_constraints'
 
 VersionProblemDebug = true
+DefaultTimeout = 5000
 
 # so that we can use test data that's already written in other tests,
 # we're accepting the same format but adapting it for our C++ wrapper
@@ -34,7 +35,7 @@ def setup_problem_for_dep_gecode(relationships)
   setup_constraint(dep_graph, relationships)
 
   dep_gecode_packages = {}
-  problem = Dep_gecode.VersionProblemCreate(dep_graph.packages.size+1, true, VersionProblemDebug, "test_slug") # extra for runlist meta package
+  problem = Dep_gecode.VersionProblemCreate(dep_graph.packages.size+1, true, VersionProblemDebug, "test_slug", DefaultTimeout) # extra for runlist meta package
 
   # all packages must be created before dependencies using them can be created
   dep_graph.each_package do |package|
@@ -123,12 +124,12 @@ end
 describe Dep_gecode do
  
   it "Can be created and destroyed" do
-    problem = Dep_gecode.VersionProblemCreate(1, true, VersionProblemDebug, "test_slug_1") 
+    problem = Dep_gecode.VersionProblemCreate(1, true, VersionProblemDebug, "test_slug_1", DefaultTimeout) 
     Dep_gecode.VersionProblemDestroy(problem)
   end
 
   it "Can be created, and have packages added to it" do
-    problem = Dep_gecode.VersionProblemCreate(2, true, VersionProblemDebug, "test_slug_2") 
+    problem = Dep_gecode.VersionProblemCreate(2, true, VersionProblemDebug, "test_slug_2", DefaultTimeout) 
     Dep_gecode.VersionProblemSize(problem).should == 2
     Dep_gecode.VersionProblemPackageCount(problem).should == 0
     packageId = Dep_gecode.AddPackage(problem, 0, 2, 8)
@@ -226,7 +227,7 @@ describe Dep_gecode do
     # Note: this test is a lower-level version of the test in
     # selector_spec titled "should indicate that the problematic
     # package is the dependency that is constrained to no versions"
-    problem = Dep_gecode.VersionProblemCreate(11, true, VersionProblemDebug, "test_slug_3")
+    problem = Dep_gecode.VersionProblemCreate(11, true, VersionProblemDebug, "test_slug_3", DefaultTimeout)
 
     # setup dep graph
     Dep_gecode.AddPackage(problem, -1, 0, 0);
@@ -279,7 +280,7 @@ describe Dep_gecode do
 
       # since @problem was already created, first free it
       Dep_gecode.VersionProblemDestroy(@problem)
-      @problem = Dep_gecode.VersionProblemCreate(4, true, VersionProblemDebug, "test_slug_4")
+      @problem = Dep_gecode.VersionProblemCreate(4, true, VersionProblemDebug, "test_slug_4", DefaultTimeout)
       @pkg_a = Dep_gecode.AddPackage(@problem, -1, 1, 0);
       @pkg_b = Dep_gecode.AddPackage(@problem, -1, 1, 0);
       @pkg_c = Dep_gecode.AddPackage(@problem, -1, 1, 0);


### PR DESCRIPTION
Use Gecode timeout instead of Ruby Timeout class

The ruby Timeout class isn't suitable to wrap FFI calls because they don't respect Ruby's thread system requirements. Instead we use the Gecode native timeout. 
