### PR TITLE
Ma/improve solves

### DIFF
--- a/ext/dep_gecode/dep_selector_to_gecode.cpp
+++ b/ext/dep_gecode/dep_selector_to_gecode.cpp
@@ -659,6 +659,10 @@ int VersionProblem::InnerSolve(VersionProblem * problem, int &itercount, Version
         DebugLogStep(solution, itercount, stats);
     }
 
+    // Solve with GIST:
+    VersionProblem * last = *best_solution ? *best_solution : problem;
+    last->GistSolveStep();
+
     // If we fail to find a solution in time we treat it as no
     // solution. We could return a special token to differentiate a
     // timeout, but that could cause problems for the FFI interface.
@@ -685,6 +689,16 @@ int VersionProblem::InnerSolve(VersionProblem * problem, int &itercount, Version
     }
 
     return result_code;
+}
+
+void VersionProblem::GistSolveStep() {
+#ifdef GIST_ENABLED
+    VersionProblem * trial = dynamic_cast<VersionProblem*>(this->copy(false));
+    trial->constrain(*this);
+    Gist::Options options;
+    Gist::dfs(trial, options);
+    delete trial;
+#endif
 }
 
 void VersionProblem::LogStats(std::ostream & o, const char * debugPrefix, const Search::Statistics & stats) {

--- a/ext/dep_gecode/dep_selector_to_gecode.cpp
+++ b/ext/dep_gecode/dep_selector_to_gecode.cpp
@@ -651,13 +651,8 @@ VersionProblem * VersionProblem::InnerSolve(VersionProblem * problem, int &iterc
             best_solution->solutionState = SOLUTION_STATE_SOLVED;
 
             ++itercount;
-            if (problem->debugLogging) {
-                DEBUG_STREAM << problem->debugPrefix << "Trial Solution #" << itercount << "===============================" << std::endl;
-                const Search::Statistics & stats = solver.statistics();
-                DEBUG_STREAM << problem->debugPrefix << "Solver stats: Prop:" << stats.propagate << " Fail:" << stats.fail << " Node:" << stats.node;
-                DEBUG_STREAM << " Depth:" << stats.depth << " memory:" << stats.memory << std::endl;
-                solution->Print(DEBUG_STREAM);
-            }
+            const Search::Statistics & stats = solver.statistics();
+            DebugLogStep(solution, itercount, stats);
         }
 
     // If we fail to find a solution in time we treat it as no
@@ -669,8 +664,7 @@ VersionProblem * VersionProblem::InnerSolve(VersionProblem * problem, int &iterc
             DEBUG_STREAM << problem->debugPrefix << "Solver FAILED: timed out with timeout set to "
                          << problem->timeout << " ms" << std::endl;
             const Search::Statistics & stats = solver.statistics();
-            DEBUG_STREAM << problem->debugPrefix << "Solver stats: Prop:" << stats.propagate << " Fail:" << stats.fail << " Node:" << stats.node;
-            DEBUG_STREAM << " Depth:" << stats.depth << " memory:" << stats.memory << std::endl;
+            LogStats(DEBUG_STREAM, problem->debugPrefix, stats);
         }
 
     } else  {
@@ -696,6 +690,20 @@ VersionProblem * VersionProblem::InnerSolve(VersionProblem * problem, int &iterc
     // We return null if there is no solution found. Timeout also returns null
     return best_solution;
 }
+
+void VersionProblem::LogStats(std::ostream & o, char * debugPrefix, const Search::Statistics & stats) {
+    o << debugPrefix << "Solver stats: Prop:" << stats.propagate << " Fail:" << stats.fail << " Node:" << stats.node;
+    o << " Depth:" << stats.depth << " memory:" << stats.memory << std::endl;
+}
+
+void VersionProblem::DebugLogStep(VersionProblem *problem, int itercount, const Search::Statistics & stats) {
+     if (problem->debugLogging) {
+         DEBUG_STREAM << problem->debugPrefix << "Trial Solution #" << itercount << "===============================" << std::endl;
+         LogStats(DEBUG_STREAM, problem->debugPrefix, stats);
+         problem->Print(DEBUG_STREAM);
+     }
+}
+
 
 VersionProblem * VersionProblem::Solve(VersionProblem * problem)
 {

--- a/ext/dep_gecode/dep_selector_to_gecode.cpp
+++ b/ext/dep_gecode/dep_selector_to_gecode.cpp
@@ -674,24 +674,16 @@ VersionProblem * VersionProblem::InnerSolve(VersionProblem * problem, int &iterc
     double elapsed_time = timer.stop();
 
     if (problem->dump_stats) {
-        if (problem->debugLogging) std::cerr << problem->debugPrefix;
-        std::cerr << "dep_selector solve: ";
-        std::cerr << ((best_solution &&  best_solution->solutionState == SOLUTION_STATE_OPTIMAL) ? "SOLVED" : "FAILED")
-                  << " ";
-        std::cerr << problem->size << " packages, " << problem->version_constraint_count << " constraints, ";
-        std::cerr << "Time: " << elapsed_time << "ms ";
         const Search::Statistics & final_stats = solver.statistics();
-        std::cerr << "Stats: " << itercount << " steps, ";
-        std::cerr << final_stats.memory << " bytes, ";
-        std::cerr << final_stats.propagate << " props, " << final_stats.node << " nodes, " << final_stats.depth << " depth ";
-        std::cerr << std::endl << std::flush;
+        int solutionState = best_solution ? best_solution->solutionState : SOLUTION_STATE_FAILED;
+        DebugLogFinal(problem, itercount, elapsed_time, final_stats, solutionState);
     }
 
     // We return null if there is no solution found. Timeout also returns null
     return best_solution;
 }
 
-void VersionProblem::LogStats(std::ostream & o, char * debugPrefix, const Search::Statistics & stats) {
+void VersionProblem::LogStats(std::ostream & o, const char * debugPrefix, const Search::Statistics & stats) {
     o << debugPrefix << "Solver stats: Prop:" << stats.propagate << " Fail:" << stats.fail << " Node:" << stats.node;
     o << " Depth:" << stats.depth << " memory:" << stats.memory << std::endl;
 }
@@ -702,6 +694,18 @@ void VersionProblem::DebugLogStep(VersionProblem *problem, int itercount, const 
          LogStats(DEBUG_STREAM, problem->debugPrefix, stats);
          problem->Print(DEBUG_STREAM);
      }
+}
+
+void VersionProblem::DebugLogFinal(VersionProblem *problem, int itercount, double elapsed_time, const Search::Statistics & stats, int solutionState) {
+     if (problem->debugLogging) std::cerr << problem->debugPrefix;
+     std::cerr << "dep_selector solve: ";
+     std::cerr << ((solutionState == SOLUTION_STATE_OPTIMAL) ? "SOLVED" : "FAILED") << " ";
+     std::cerr << problem->size << " packages, " << problem->version_constraint_count << " constraints, ";
+     std::cerr << "Time: " << elapsed_time << "ms ";
+
+     std::cerr << "Stats: " << itercount << " steps, ";
+     LogStats(std::cerr, (problem->debugLogging ? problem->debugPrefix : ""), stats);
+     std::cerr << std::flush;
 }
 
 

--- a/ext/dep_gecode/dep_selector_to_gecode.h
+++ b/ext/dep_gecode/dep_selector_to_gecode.h
@@ -162,6 +162,11 @@ public:
   void ConstrainVectorLessThanBest(IntVarArgs & current, IntVarArgs & best);
   void BuildCostVector(IntVarArgs & costVector) const;
 
+  void AddBrancherPoor(std::ostream & o);
+  void AddBrancherOriginal(std::ostream & o);
+  void AddBrancherV2(std::ostream & o);
+  void AddBrancherAtLatest(std::ostream & o);
+
   friend class VersionProblemPool;
 };
 

--- a/ext/dep_gecode/dep_selector_to_gecode.h
+++ b/ext/dep_gecode/dep_selector_to_gecode.h
@@ -114,15 +114,13 @@ public:
   void PrintPackageVar(std::ostream & out, int packageId) ;
   const char * DebugPrefix() const { return debugPrefix; }
 
-  static VersionProblem *InnerSolve(VersionProblem * problem, int & itercount);
-
-//  static VersionProblem *InnerSolveGist(VersionProblem * problem, int & itercount);
+  static int InnerSolve(VersionProblem * problem, int & itercount, VersionProblem** solution);
 
   static void DebugLogStep(VersionProblem *problem, int itercount, const Search::Statistics & stats);
   static void LogStats(std::ostream & o, const char * debugPrefix, const Search::Statistics & stats);
   static void DebugLogFinal(VersionProblem *problem, int itercount, double elapsed_time, const Search::Statistics & stats, int solutionState);
 
-  static VersionProblem *Solve(VersionProblem *problem);
+  static int Solve(VersionProblem *problem, VersionProblem**solution);
 
  protected:
   int instance_id;

--- a/ext/dep_gecode/dep_selector_to_gecode.h
+++ b/ext/dep_gecode/dep_selector_to_gecode.h
@@ -161,12 +161,4 @@ public:
 template<class T> void PrintVarAligned(const char * message, T & var);
 template<class S, class T> void PrintVarAligned(const char * message, S & var1, T & var2);
 
-class Solver {
- public:
-  Solver(VersionProblem *s);
-  VersionProblem GetNextSolution();
- private:
-  Restart<VersionProblem> solver;
-};
-
 #endif // dep_selector_to_gecode_h

--- a/ext/dep_gecode/dep_selector_to_gecode.h
+++ b/ext/dep_gecode/dep_selector_to_gecode.h
@@ -112,6 +112,8 @@ public:
   // Debug and utility functions
   void Print(std::ostream &out);
   void PrintPackageVar(std::ostream & out, int packageId) ;
+  void GistSolveStep();
+
   const char * DebugPrefix() const { return debugPrefix; }
 
   static int InnerSolve(VersionProblem * problem, int & itercount, VersionProblem** solution);

--- a/ext/dep_gecode/dep_selector_to_gecode.h
+++ b/ext/dep_gecode/dep_selector_to_gecode.h
@@ -115,6 +115,12 @@ public:
   const char * DebugPrefix() const { return debugPrefix; }
 
   static VersionProblem *InnerSolve(VersionProblem * problem, int & itercount);
+
+//  static VersionProblem *InnerSolveGist(VersionProblem * problem, int & itercount);
+
+  static void DebugLogStep(VersionProblem *problem, int itercount, const Search::Statistics & stats);
+  static void LogStats(std::ostream & o, char * debugPrefix, const Search::Statistics & stats);
+
   static VersionProblem *Solve(VersionProblem *problem);
 
  protected:

--- a/ext/dep_gecode/dep_selector_to_gecode.h
+++ b/ext/dep_gecode/dep_selector_to_gecode.h
@@ -119,7 +119,8 @@ public:
 //  static VersionProblem *InnerSolveGist(VersionProblem * problem, int & itercount);
 
   static void DebugLogStep(VersionProblem *problem, int itercount, const Search::Statistics & stats);
-  static void LogStats(std::ostream & o, char * debugPrefix, const Search::Statistics & stats);
+  static void LogStats(std::ostream & o, const char * debugPrefix, const Search::Statistics & stats);
+  static void DebugLogFinal(VersionProblem *problem, int itercount, double elapsed_time, const Search::Statistics & stats, int solutionState);
 
   static VersionProblem *Solve(VersionProblem *problem);
 

--- a/ext/dep_gecode/dep_selector_to_gecode.h
+++ b/ext/dep_gecode/dep_selector_to_gecode.h
@@ -28,6 +28,11 @@
 #include <gecode/driver.hh>
 #include <gecode/int.hh>
 #include <gecode/minimodel.hh>
+#include <gecode/support.hh>
+
+#if GECODE_VERSION_NUMBER < 400000
+#define GECODE_VERSION_3
+#endif
 
 using namespace Gecode;
 

--- a/ext/dep_gecode/dep_selector_to_gecode_interface.cpp
+++ b/ext/dep_gecode/dep_selector_to_gecode_interface.cpp
@@ -128,6 +128,6 @@ int GetSolutionState(VersionProblem * problem)
     return problem->GetSolutionState();
 }
 
-VersionProblem * Solve(VersionProblem * problem)  {
-  return VersionProblem::Solve(problem);
+int Solve(VersionProblem * problem, VersionProblem ** solution)  {
+    return VersionProblem::Solve(problem, solution);
 }

--- a/ext/dep_gecode/dep_selector_to_gecode_interface.h
+++ b/ext/dep_gecode/dep_selector_to_gecode_interface.h
@@ -75,7 +75,7 @@ extern "C" {
   void VersionProblemDump(VersionProblem * problem);
   void VersionProblemPrintPackageVar(VersionProblem * problem, int packageId);
 
-  VersionProblem * Solve(VersionProblem * problem);
+  int Solve(VersionProblem * problem, VersionProblem** solution);
 
 #ifdef __cplusplus
 }

--- a/ext/dep_gecode/dep_selector_to_gecode_interface.h
+++ b/ext/dep_gecode/dep_selector_to_gecode_interface.h
@@ -25,11 +25,14 @@
 extern "C" {
 #endif // __cplusplus
 
+#define SOLUTION_STATE_FAILED    0
 #define SOLUTION_STATE_UNSTARTED 1
 #define SOLUTION_STATE_FINALIZED 2
 #define SOLUTION_STATE_SOLVED    3
 #define SOLUTION_STATE_TIMED_OUT 4
 #define SOLUTION_STATE_OPTIMAL   5
+
+
 
 #ifdef __cplusplus
   class VersionProblem;
@@ -66,7 +69,7 @@ extern "C" {
 
   int GetDisabledVariableCount(VersionProblem *problem);
 
-  void SetTimeout(VersionProblem *problem, unsigned long int timeout);        
+  void SetTimeout(VersionProblem *problem, unsigned long int timeout);
   int GetSolutionState(VersionProblem *problem);
 
   void VersionProblemDump(VersionProblem * problem);

--- a/lib/dep_selector/dep_gecode.rb
+++ b/lib/dep_selector/dep_gecode.rb
@@ -62,7 +62,7 @@ module Dep_gecode
   attach_function :AddVersionConstraint, [:pointer, :int, :int, :int, :int, :int], :void
 
   # VersionProblem * Solve(VersionProblem * problem);
-  attach_function :Solve, [:pointer], :pointer
+  attach_function :Solve, [:pointer, :pointer], :int
 
   # int GetDisabledVariableCount(VersionProblem *problem);
   attach_function :GetDisabledVariableCount, [:pointer], :int
@@ -84,9 +84,6 @@ module Dep_gecode
 
   # int GetPackageMin(VersionProblem *problem, int packageId);
   attach_function :GetPackageMin, [:pointer, :int], :int
-
-  # int GetSolutionState(VersionProblem * problem);
-  attach_function :GetSolutionState, [:pointer], :int
 
   # void SetTimeout(VersionProblem * problem, unsigned long int);
   attach_function :SetTimeout, [:pointer, :ulong], :void

--- a/lib/dep_selector/dep_selector_version.rb
+++ b/lib/dep_selector/dep_selector_version.rb
@@ -1,3 +1,3 @@
 module DepSelector
-  VERSION = "1.0.3"
+  VERSION = "1.0.4"
 end


### PR DESCRIPTION
The key change is tweaks to the branchers to avoid some pathological cases with complex problems. 

Choosing the package_versions variable to be INT_VAR_SIZE_MIN causes us to spend a large amount of time permuting variables that don't generate many propagations. Switching that to INT_VAR_DEGREE_MAX causes the solver to focus on the most 'influential' package versions first.

Also included are some refactors; a cleanup to avoid segfaulting with the new timer code.

Finally there's preliminary support for the GIST solve visualization tool; that was very helpful to tune the branchers.