### PR TITLE
Showing proper error message instead of segfault error for unsolvable sets

### DIFF
--- a/ext/dep_gecode/dep_selector_to_gecode.cpp
+++ b/ext/dep_gecode/dep_selector_to_gecode.cpp
@@ -843,7 +843,9 @@ int VersionProblem::Solve(VersionProblem * problem, VersionProblem ** solution)
         DEBUG_STREAM << problem->DebugPrefix() << "Solver Best Solution " << *solution << std::endl << std::flush;
     }
 
-    pool->Delete(*solution);
+    if (*solution) {
+        pool->Delete(*solution);
+    }
     problem->pool = 0;
 
     pool->DeleteAll();


### PR DESCRIPTION
# Issues Resolved
https://github.com/berkshelf/berkshelf/issues/1650
https://github.com/berkshelf/berkshelf/issues/1682
https://github.com/chef/dep-selector-libgecode/issues/57

*Note*: As mentioned in [this](https://github.com/chef/dep-selector#learn-by-example) section at the bottom, `not all (dependency graph, solution constraint) systems are satisfiable, so we must return useful error information`.