### PR TITLE
Update File.exists? -> File.exist? for compatibility with Ruby 3.4+

### DIFF
--- a/lib/dep_selector/dependency_graph.rb
+++ b/lib/dep_selector/dependency_graph.rb
@@ -61,7 +61,7 @@ module DepSelector
           end
 
         logId = SecureRandom.uuid
-        debugFlag = DebugOptionFile && File::exists?(DebugOptionFile)
+        debugFlag = DebugOptionFile && File::exist?(DebugOptionFile)
         Debug.log.level = Logger::INFO unless debugFlag
         Debug.log.formatter = proc do |severity, datetime, progname, msg|
           "#{logId}: #{msg}\n"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Failed because of missing File.exists? method in Ruby 3.4

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
